### PR TITLE
Work for 80117

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@ LDAP service
 ============
 
 This is a Dockerfile for an ldap service where the full slapd.conf is stored in an environment variable called `LDAP_CONF`.
-Optional environment variables: `SSL_KEY`, `SSL_CERT`, `SSL_CA_CERTS` and `LDIF_SEED_URL`.
+Optional environment variables: `SSL_KEY`, `SSL_CERT`, `SSL_CA_CERTS`, `LDIF_SEED_URL` and `LDIF_SEED_SUFFIX`.
 
 The optional `LDIF_SEED_URL` is a URL to a file containing LDIF entries created by slapcat. It can be any URL known to `curl` - including `file:`.
 The file will be loaded before the LDAP daemon is started.
+
+The optional `LDIF_SEED_SUFFIX` is useful in the case of having multiple backend databases in the slapd.conf file. It will be used to determine which database to add entries to.
 
 Example
 -------

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,9 +64,9 @@ install_sslkey
 if [ -n "$LDIF_SEED_URL" ] && [ ! -e .skip-ldif ]; then
     touch .skip-ldif
     curl -s -o /tmp/seed.ldif "$LDIF_SEED_URL"
-    if [ -n "$LDIF_SEED_SUFIX" ]; then
-        echo "Running slapadd with $LDIF_SEED_URL: /usr/sbin/slapadd -b \"$LDIF_SEED_SUFIX\" -c -l /tmp/seed.ldif"
-        /usr/sbin/slapadd -b "$LDIF_SEED_SUFIX" -c -v -l /tmp/seed.ldif
+    if [ -n "$LDIF_SEED_SUFFIX" ]; then
+        echo "Running slapadd with $LDIF_SEED_URL: /usr/sbin/slapadd -b \"$LDIF_SEED_SUFFIX\" -c -l /tmp/seed.ldif"
+        /usr/sbin/slapadd -b "$LDIF_SEED_SUFFIX" -c -v -l /tmp/seed.ldif
     else
         echo "Running slapadd with $LDIF_SEED_URL: /usr/sbin/slapadd -c -l /tmp/seed.ldif"
         /usr/sbin/slapadd -c -v -l /tmp/seed.ldif

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,8 +61,10 @@ mv /etc/openldap/slapd.d  /etc/openldap/slapd.d.disabled
 
 install_sslkey
 
-if [ -n "$LDIF_SEED_URL" ]; then
-    curl -s -o /tmp/seed.ldif "$LDIF_SEED_URL" && /usr/sbin/slapadd -l /tmp/seed.ldif
+if [ -n "$LDIF_SEED_URL" ] && [ ! -e .skip-ldif ]; then
+    touch .skip-ldif
+    echo "Running slapadd with $LDIF_SEED_URL"
+    curl -s -o /tmp/seed.ldif "$LDIF_SEED_URL" && /usr/sbin/slapadd -b "ou=Business Reporters,o=EIONET,l=Europe" -c -v -l /tmp/seed.ldif
 fi
 ###########################################################
 # Start LDAP server

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,10 +63,18 @@ install_sslkey
 
 if [ -n "$LDIF_SEED_URL" ] && [ ! -e .skip-ldif ]; then
     touch .skip-ldif
-    echo "Running slapadd with $LDIF_SEED_URL"
-    curl -s -o /tmp/seed.ldif "$LDIF_SEED_URL" && /usr/sbin/slapadd -b "ou=Business Reporters,o=EIONET,l=Europe" -c -v -l /tmp/seed.ldif
+    curl -s -o /tmp/seed.ldif "$LDIF_SEED_URL"
+    if [ -n "$LDIF_SEED_SUFIX" ]; then
+        echo "Running slapadd with $LDIF_SEED_URL: /usr/sbin/slapadd -b \"$LDIF_SEED_SUFIX\" -c -l /tmp/seed.ldif"
+        /usr/sbin/slapadd -b "$LDIF_SEED_SUFIX" -c -v -l /tmp/seed.ldif
+    else
+        echo "Running slapadd with $LDIF_SEED_URL: /usr/sbin/slapadd -c -l /tmp/seed.ldif"
+        /usr/sbin/slapadd -c -v -l /tmp/seed.ldif
+    fi
 fi
+
 ###########################################################
 # Start LDAP server
 ###########################################################
+echo "Start LDAP server"
 exec /usr/sbin/slapd -h "${LDAPSERVERS:-ldap:/// ldaps:/// ldapi:///}" -u ldap -d "${SLAPD_DEBUG_LEVEL:-16640}"


### PR DESCRIPTION
The changes are a fix for the problem reported under https://taskman.eionet.europa.eu/issues/80117#note-36:

I introduced the use of two arguments:

1. -b suffix - to indicate to which database to add entries

2. -c - to enable continue (ignore errors) mode
