### PR TITLE
Upgrade base image to Centos7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM centos:7
 MAINTAINER Søren Roug <soren.roug@eea.europa.eu>
 
 # Can be mapped for a primary server


### PR DESCRIPTION
Upgrade image to Centos 7 to work around a bug in the Centos 6 implementation of openldap