### PR TITLE
Workaround for DB_CONFIG copy when /var/lib/ldap on external volume

### DIFF
--- a/DB_CONFIG
+++ b/DB_CONFIG
@@ -22,6 +22,8 @@ set_cachesize 0 268435456 1
 # Transaction Log settings
 set_lg_regionmax 262144
 set_lg_bsize 2097152
+set_flags DB_LOG_AUTO_REMOVE
+
 #set_lg_dir logs
 
 # Note: special DB_CONFIG flags are no longer needed for "quick"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y openldap-servers openldap openldap-clients wget \
 
 COPY entrypoint.sh /
 COPY eionet.schema /etc/openldap/schema/
-COPY DB_CONFIG /var/lib/ldap/
+COPY DB_CONFIG /etc/openldap/
 
 EXPOSE 389 636
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,6 +57,11 @@ fi
 
 create_conf
 
+# workaround for /var/lib/ldap on external volume 
+if [ ! -f /var/lib/ldap/DB_CONFIG ]; then
+	cp /etc/openldap/DB_CONFIG /var/lib/ldap/
+fi
+
 mv /etc/openldap/slapd.d  /etc/openldap/slapd.d.disabled
 
 install_sslkey


### PR DESCRIPTION
Please merge this workaround into the main branch.